### PR TITLE
Add SQLite installation

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -121,6 +121,10 @@ npm install -g grunt-cli
 npm install -g gulp
 npm install -g bower
 
+# Install SQLite
+
+apt-get install -y sqlite3 libsqlite3-dev
+
 # Install MySQL
 
 debconf-set-selections <<< "mysql-server mysql-server/root_password password secret"


### PR DESCRIPTION
SQLite can be pretty useful and it seems like using it for local development might be an answer for those concerned that "vagrant destroy" will remove the databases. 
