### PR TITLE
Forward 35729 port (LiveReload) to homestead

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	config.vm.network "forwarded_port", guest: 80, host: 8000
 	config.vm.network "forwarded_port", guest: 3306, host: 33060
 	config.vm.network "forwarded_port", guest: 5432, host: 54320
+	config.vm.network "forwarded_port", guest: 35729, host: 35729
 
 	# Run The Base Provisioning Script
 	config.vm.provision "shell" do |s|


### PR DESCRIPTION
This allows for communicating with [LiveReload protocol-based processes](http://feedback.livereload.com/knowledgebase/articles/86174-livereload-protocol).

Use case is running `grunt watch` (or similar) on the virtual machine, and using a [browser extension](https://github.com/livereload/livereload-extensions) to reload the page when files change. (Yes, this currently could be done by running `grunt watch` on the host machine, but if your deploy process normally involves complex grunt scripts, files may change due to server-side triggers. It's helpful to have everything run as they would in production (with the simple addition of watch for development).
