### PR TITLE
Swapping php5-mysql to use the Native Driver: php5-mysqlnd

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -37,7 +37,7 @@ ln -sf /usr/share/zoneinfo/America/Chicago /etc/localtime
 # Install PHP Stuffs
 
 apt-get install -y php5-cli php5-dev php-pear \
-php5-mysql php5-pgsql php5-sqlite \
+php5-mysqlnd php5-pgsql php5-sqlite \
 php5-apcu php5-json php5-curl php5-dev php5-gd \
 php5-gmp php5-imap php5-mcrypt php5-xdebug \
 php5-memcached php5-redis


### PR DESCRIPTION
Ran into a problem where data types were not retained when using toArray()

Controller method:

```
    public function showWithAllData($id)
    {
        // Do Response
        if (Request::ajax()) {

            $jsonResponse = array(
                'draft'=>null,
                'cards'=>null,
                'users'=>null,
                'picks'=>null
            );

            // Get the Draft
            $thisDraft = Draft::with('user.avatar')
                ->with('currentPick')
                ->find($id);

            // Get the Card IDs and user IDs for the Draft
            // Create a 'sideloaded' style JSON response
            $jsonResponse['draft'] = $thisDraft->toArray();
            $jsonResponse['users'] = $thisDraft->user->toArray();
            $jsonResponse['cards'] = $this->getCardsForDraft($thisDraft->id)->toArray();
            $jsonResponse['picks'] = $this->getPicksForDraft($thisDraft->id)->toArray();

            return Response::json($jsonResponse);

        } else {

            return Redirect::to('/drafts');
        }
    }
```

Running an ajax call to a route to that controller method will return JSON. The issue is when we check any of the values that should be integers, they're strings. Swapping from php5-mysql to php5-mysqlnd resolves the issue. Here is a stack overflow that may explain the issue better: http://stackoverflow.com/questions/20079320/php-pdo-mysql-returns-integer-columns-as-strings-on-ubuntu-but-as-integers-o
