### PR TITLE
vmware_fusion support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	# Configure The Box
-	config.vm.box = "ubuntu/trusty64"
+	config.vm.box = "chef/ubuntu-14.04"
 	config.vm.hostname = "homestead"
 
 	config.vm.network :private_network, ip: "192.168.33.10"
@@ -11,6 +11,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	  vb.customize ["modifyvm", :id, "--memory", "2048"]
 	  vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 	  vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+	end
+
+	config.vm.provider "vmware_fusion" do |v|
+	  v.vmx["memsize"] = "2048"
 	end
 
 	# Configure Port Forwarding


### PR DESCRIPTION
Adds support for Vmware provider.

The base box was changed from ubuntu to chef, because ubuntu only provides Virtualbox boxes. Chef's boxes are built from opensource Packer templates, which can be found here: https://github.com/opscode/bento/blob/master/packer/ubuntu-14.04-amd64.json

New build instructions:
```
vagrant box add chef/ubuntu-14.04 --provider=virtualbox OR vmware_desktop
vagrant up
```