### PR TITLE
Fix provisioning error when copying public key

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -168,3 +168,8 @@ sudo /etc/init.d/beanstalkd start
 # Write Bash Aliases
 
 cp /vagrant/aliases /home/vagrant/.bash_aliases
+
+# Ensure SSH authorized_keys file exists
+
+mkdir /home/vagrant/.ssh
+touch /home/vagrant/.ssh/authorized_keys


### PR DESCRIPTION
When trying to copy host's public key to the VM's authorized_keys file an error is thrown since the file does not already exist.

```
$ vagrant up                              
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'laravel/homestead'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'laravel/homestead' is up to date...
==> default: Setting the name of the VM: Homestead_default_1405646752738_59758
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 80 => 8000 (adapter 1)
    default: 3306 => 33060 (adapter 1)
    default: 5432 => 54320 (adapter 1)
    default: 22 => 2222 (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Setting hostname...
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /vagrant => /home/jnorth/Homestead
    default: /home/vagrant => /home/jnorth/Code
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: tee: 
==> default: /home/vagrant/.ssh/authorized_keys
==> default: : No such file or directory
==> default: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDhtq1Sxpj67+Xh2gsiEwjykkZVMq52jX7ZWD7FslzysHAKD2U0ig0ZEN3kH5q7H5QdAYM2q6j0S6pe5i3GBcMDTtediyIt9NzCTUkW7taRVLLR/PCw9q8kixvctuYpeKJAfhyyUB7tZyAxBOC0JlxSxzfJaM1vzBK4fJflyaJZRYWKoC/d3EZml5Jv3uwPymrUc2pkjonGFH5q+QgUr0UqXgUnCzswjTpuq4MnIjAJicy21BG34MbU6A72pvbE87n01RR9mg4y+kB5+KWII46LnUli3kq2dUnSb+xdR1bqsGBPi5UOevD40FjLFgpWUTDM4kLY8MoDCUEsXwjVDw1L jnorth@protonmail.ch
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

chmod +x /tmp/vagrant-shell && /tmp/vagrant-shell "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDhtq1Sxpj67+Xh2gsiEwjykkZVMq52jX7ZWD7FslzysHAKD2U0ig0ZEN3kH5q7H5QdAYM2q6j0S6pe5i3GBcMDTtediyIt9NzCTUkW7taRVLLR/PCw9q8kixvctuYpeKJAfhyyUB7tZyAxBOC0JlxSxzfJaM1vzBK4fJflyaJZRYWKoC/d3EZml5Jv3uwPymrUc2pkjonGFH5q+QgUr0UqXgUnCzswjTpuq4MnIjAJicy21BG34MbU6A72pvbE87n01RR9mg4y+kB5+KWII46LnUli3kq2dUnSb+xdR1bqsGBPi5UOevD40FjLFgpWUTDM4kLY8MoDCUEsXwjVDw1L jnorth@protonmail.ch
"

Stdout from the command:

ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDhtq1Sxpj67+Xh2gsiEwjykkZVMq52jX7ZWD7FslzysHAKD2U0ig0ZEN3kH5q7H5QdAYM2q6j0S6pe5i3GBcMDTtediyIt9NzCTUkW7taRVLLR/PCw9q8kixvctuYpeKJAfhyyUB7tZyAxBOC0JlxSxzfJaM1vzBK4fJflyaJZRYWKoC/d3EZml5Jv3uwPymrUc2pkjonGFH5q+QgUr0UqXgUnCzswjTpuq4MnIjAJicy21BG34MbU6A72pvbE87n01RR9mg4y+kB5+KWII46LnUli3kq2dUnSb+xdR1bqsGBPi5UOevD40FjLFgpWUTDM4kLY8MoDCUEsXwjVDw1L jnorth@protonmail.ch


Stderr from the command:

tee: /home/vagrant/.ssh/authorized_keys: No such file or directory
```
