### PR TITLE
Adds the `exuberant-ctags` package

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -21,7 +21,7 @@ apt-get update
 
 # Install Some Basic Packages
 
-apt-get install -y build-essential curl dos2unix gcc git libmcrypt4 libpcre3-dev \
+apt-get install -y build-essential curl dos2unix exuberant-ctags gcc git libmcrypt4 libpcre3-dev \
 make python2.7-dev python-pip re2c supervisor unattended-upgrades whois vim
 
 # Install A Few Helpful Python Packages


### PR DESCRIPTION
Since vim is already installed, and ctags and vim go hand in hand, and there is a [laracast](https://laracasts.com/lessons/just-use-ctags) about it, this change adds the [exuberant-ctags](http://ctags.sourceforge.net/) package to the default list of packages.
