### PR TITLE
Increase xdebug maximum nesting level

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -21,9 +21,9 @@ apt-get update
 
 # Install Some Basic Packages
 
-apt-get install -y build-essential curl dos2unix gcc git libmcrypt4 libpcre3-dev \
-make python2.7-dev python-pip re2c supervisor unattended-upgrades whois vim \
-coffeescript ruby-sass
+apt-get install -y build-essential coffeescript curl dos2unix gcc git libmcrypt4 \
+libpcre3-dev make python2.7-dev python-pip re2c ruby-sass supervisor \
+unattended-upgrades whois vim
 
 # Install A Few Helpful Python Packages
 


### PR DESCRIPTION
Laravel framework can generate some pretty tall call stacks. Hitting the default limit of nesting limit of 100 is pretty easy to do. I propose the limit be increased.
