### PR TITLE
Locale setting to avoid common ubuntu pitfalls

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -9,7 +9,7 @@ apt-get upgrade -y
 
 # Force locale to avoid common localization pitfalls
 
-echo "LC_ALL=en_US.UTF-8" > /etc/default/locale
+echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
 locale-gen en_US.UTF-8
 
 # Install Some PPAs

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -6,6 +6,12 @@ apt-get update
 
 apt-get upgrade -y
 
+
+# Force locale to avoid common localization pitfalls
+
+echo "LC_ALL=en_US.UTF-8" > /etc/default/locale
+locale-gen en_US.UTF-8
+
 # Install Some PPAs
 
 apt-get install -y software-properties-common


### PR DESCRIPTION
This would prevent ubuntu from warning:

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_CTYPE = "UTF-8",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```