### PR TITLE
Enable swap memory

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -210,6 +210,12 @@ apt-get install -y redis-server memcached beanstalkd
 sudo sed -i "s/#START=yes/START=yes/" /etc/default/beanstalkd
 sudo /etc/init.d/beanstalkd start
 
+# Enable swap memory
+
+/bin/dd if=/dev/zero of=/var/swap.1 bs=1M count=1024
+/sbin/mkswap /var/swap.1
+/sbin/swapon /var/swap.1
+
 # Write Bash Aliases
 
 cp /vagrant/aliases /home/vagrant/.bash_aliases


### PR DESCRIPTION
Those who use a lower memory limit for homestead have been running into the error below when executing `composer update` or `composer install`:

```
Fatal error: Uncaught exception 'ErrorException' with message 'fork failed - Cannot allocate memory' in phar://composer.phar/bin/../src/../vendor/symfony/console/Symfony/Component/Console/Application.php:983
```

Creating a swap memory solves that. Thanks [Mark Vaughn](https://coderwall.com/p/grhteq)!