### PR TITLE
Fix npm config permissions

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -168,10 +168,6 @@ sudo su vagrant <<'EOF'
 /usr/bin/npm install -g bower
 EOF
 
-npm install -g grunt-cli
-npm install -g gulp
-npm install -g bower
-
 # Install SQLite
 
 apt-get install -y sqlite3 libsqlite3-dev

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -162,6 +162,12 @@ groups vagrant
 # Install Node
 
 apt-get install -y nodejs
+sudo su vagrant <<'EOF'
+/usr/bin/npm install -g grunt-cli
+/usr/bin/npm install -g gulp
+/usr/bin/npm install -g bower
+EOF
+
 npm install -g grunt-cli
 npm install -g gulp
 npm install -g bower


### PR DESCRIPTION
Changed script to install npm packages under vagrant user, to avoid permission issues as highlighted here: http://stackoverflow.com/questions/12231846/npm-will-not-install-express. I've had permission issues with ~/.npm in the past, which prompted me to look into this.