### PR TITLE
Added mailcatcher incl. upstart job

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	config.vm.network "forwarded_port", guest: 3306, host: 33060
 	config.vm.network "forwarded_port", guest: 5432, host: 54320
 	config.vm.network "forwarded_port", guest: 35729, host: 35729
+	config.vm.network "forwarded_port", guest: 1080, host: 10800
 
 	# Run The Base Provisioning Script
 	config.vm.provision "shell" do |s|

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -213,3 +213,37 @@ sudo /etc/init.d/beanstalkd start
 # Write Bash Aliases
 
 cp /vagrant/aliases /home/vagrant/.bash_aliases
+
+
+
+# Install Mailcatcher
+
+# Create user & logdir
+adduser --gecos "" --home /var/spool/mailcatcher --shell /bin/true --disabled-password mailcatcher
+mkdir -p /var/log/mailcatcher
+chown mailcatcher:mailcatcher /var/log/mailcatcher
+chmod 755 /var/log/mailcatcher
+
+# Install mailcatcher
+apt-get install -y ruby-dev
+gem install mailcatcher
+
+# Create upstart job
+echo "# mailcatcher - mock smtp server
+#
+# mailCatcher runs a super simple SMTP server which catches any
+# message sent to it to display in a web interface.
+
+description \"mock smtp server\"
+
+start on runlevel [2345]
+stop on starting rc RUNLEVEL=[016]
+
+setuid mailcatcher
+setgid mailcatcher
+
+exec nohup /usr/local/bin/mailcatcher -f --ip 0.0.0.0  >> /var/log/mailcatcher/mailcatcher.log 2>&1
+" > /etc/init/mailcatcher.conf
+
+# Start Mailcatcher
+start mailcatcher


### PR DESCRIPTION
[Mailcatcher](http://mailcatcher.me) is a neat little tool which allows you to intercept all outgoing mail and display it in a nice web UI. This way you don't have to setup a mail account or change smtp credentials just to test your projects mail sending capabilities.

This will install mail catcher, forward the web UI to port 10800 and install an upstart job.

Mailcatchers dummy smtp server runs on port 1025, not credentials or TLS needed.