### PR TITLE
MySQL 5.6 cannot be installed on 512MB VM…

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -182,7 +182,7 @@ apt-get install -y sqlite3 libsqlite3-dev
 
 debconf-set-selections <<< "mysql-server mysql-server/root_password password secret"
 debconf-set-selections <<< "mysql-server mysql-server/root_password_again password secret"
-apt-get install -y mysql-server-5.6
+apt-get install -y mysql-server-5.5
 
 # Configure MySQL Remote Access
 


### PR DESCRIPTION
Mysql downgraded to 5.5 because its memory footprint is too big…
This allows to deploy to a 512MB ram droplet on DigitalOcean or micro unit on AWS and develop with the same software versions…