### PR TITLE
Minimize disk image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,10 @@ vagrant halt
 # shrink disk (assumes running on osx)
 /Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager -k .vagrant/machines/default/vmware_fusion/*-*-*-*-*/disk.vmdk
 # 'vagrant package' does not work with vmware boxes (http://docs.vagrantup.com/v2/vmware/boxes.html)
-tar cvzf vmware_fusion.box .vagrant/machines/default/vmware_fusion/*-*-*-*-*/*
+cd .vagrant/machines/default/vmware_fusion/*-*-*-*-*/
+rm -f vmware*.log
+tar cvzf ../../../../../vmware_fusion.box *
+cd ../../../../../
 
 ls -lh vmware_fusion.box
 vagrant destroy -f

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -235,3 +235,10 @@ sudo /etc/init.d/beanstalkd start
 /bin/dd if=/dev/zero of=/var/swap.1 bs=1M count=1024
 /sbin/mkswap /var/swap.1
 /sbin/swapon /var/swap.1
+
+# Minimize The Disk Image
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY
+# Block until the empty file has been removed, otherwise, Packer
+# will try to kill the box while the disk is still full and that's bad
+sync

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -237,8 +237,7 @@ sudo /etc/init.d/beanstalkd start
 /sbin/swapon /var/swap.1
 
 # Minimize The Disk Image
+echo "Minimizing disk image..."
 dd if=/dev/zero of=/EMPTY bs=1M
 rm -f /EMPTY
-# Block until the empty file has been removed, otherwise, Packer
-# will try to kill the box while the disk is still full and that's bad
 sync


### PR DESCRIPTION
This dramatically reduces the size of the box to upload:

```shell
$ ls -aslh *.box
 871632 -rw-r--r--  1 joshfng  staff   426M Mar  6 08:25 virtualbox.box
1824520 -rw-r--r--  1 joshfng  staff   891M Mar  6 08:33 vmware_fusion.box
```

The command writes zeros to the empty space on the disk, then when the boxes are tar'd up, those zeros are not copied into the archive. This is known as a sparse copy/sparse image.