### PR TITLE
Fix issues related to blackfire and hhvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vagrant
 *.box
+*.log

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,7 @@
 vagrant destroy -f
 rm -rf .vagrant
 
-#time vagrant up --provider virtualbox 2>&1 | tee virtualbox-build-output.log
-vagrant up --provider virtualbox
+time vagrant up --provider virtualbox 2>&1 | tee virtualbox-build-output.log
 vagrant halt
 vagrant package --base `ls ~/VirtualBox\ VMs | grep settler` --output virtualbox.box
 
@@ -13,8 +12,7 @@ ls -lh virtualbox.box
 vagrant destroy -f
 rm -rf .vagrant
 
-#time vagrant up --provider vmware_fusion 2>&1 | tee vmware-build-output.log
-vagrant up --provider vmware_fusion
+time vagrant up --provider vmware_fusion 2>&1 | tee vmware-build-output.log
 vagrant halt
 # defrag disk (assumes running on osx)
 /Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager -d .vagrant/machines/default/vmware_fusion/*-*-*-*-*/disk.vmdk

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -13,7 +13,7 @@ locale-gen en_US.UTF-8
 
 # Install Some PPAs
 
-apt-get install -y software-properties-common
+apt-get install -y software-properties-common curl
 
 apt-add-repository ppa:nginx/stable -y
 apt-add-repository ppa:rwky/redis -y
@@ -32,7 +32,7 @@ apt-get update
 
 # Install Some Basic Packages
 
-apt-get install -y build-essential curl dos2unix gcc git libmcrypt4 libpcre3-dev \
+apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev \
 make python2.7-dev python-pip re2c supervisor unattended-upgrades whois vim
 
 # Install A Few Helpful Python Packages
@@ -97,7 +97,7 @@ service nginx restart
 # Add The HHVM Key & Repository
 
 wget -O - http://dl.hhvm.com/conf/hhvm.gpg.key | apt-key add -
-echo deb http://dl.hhvm.com/ubuntu trusty main | tee /etc/apt/sources.list.d/hhvm.list
+echo deb http://dl.hhvm.com/ubuntu utopic main | tee /etc/apt/sources.list.d/hhvm.list
 apt-get update
 apt-get install -y hhvm
 


### PR DESCRIPTION
The issue with blackfire was related to trying to `curl` the apt signing key before `curl` was actually installed.

The issue with HHVM was the Ubuntu 'codename' was no longer 'trusty` so the wrong deb was being pulled. I have verfied that hhvm does install correctly and start up.

Log snippet of successful build below:

blackfire:
```shell
==> default: The following NEW packages will be installed:
==> default:   blackfire-agent blackfire-php
==> default: 0 upgraded, 2 newly installed, 0 to remove and 4 not upgraded.
==> default: Need to get 4,443 kB of archives.
==> default: After this operation, 14.5 MB of additional disk space will be used.
==> default: Get:1 http://packages.blackfire.io/debian/ any/main blackfire-agent amd64 0.21.2 [3,745 kB]
==> default: Get:2 http://packages.blackfire.io/debian/ any/main blackfire-php amd64 0.20.6 [698 kB]
==> default: dpkg-preconfigure: unable to re-open stdin: No such file or directory
==> default: Fetched 4,443 kB in 9s (451 kB/s)
==> default: Selecting previously unselected package blackfire-agent.
==> default: (Reading database ... 44686 files and directories currently installed.)
==> default: Preparing to unpack .../blackfire-agent_0.21.2_amd64.deb ...
==> default: Unpacking blackfire-agent (0.21.2) ...
==> default: Selecting previously unselected package blackfire-php.
==> default: Preparing to unpack .../blackfire-php_0.20.6_amd64.deb ...
==> default: Unpacking blackfire-php (0.20.6) ...
==> default: Processing triggers for man-db (2.7.0.2-2) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Setting up blackfire-agent (0.21.2) ...
==> default: creating blackfire system user
==> default:
==> default:
==> default: 	ADDITIONAL STEP REQUIRED!
==> default:
==> default: 	If this is a new install please run:
==> default:
==> default: 	sudo blackfire-agent --register
==> default: 	sudo /etc/init.d/blackfire-agent start
==> default: Setting up blackfire-php (0.20.6) ...
==> default: blackfire-php install completed.
```

hhvm
```shell
==> default: Setting up hhvm (3.5.1~utopic) ...
==> default: ********************************************************************
==> default: * HHVM is installed.
==> default: * 
==> default: * Running PHP web scripts with HHVM is done by having your webserver talk to HHVM
==> default: * over FastCGI. Install nginx or Apache, and then:
==> default: * $ sudo /usr/share/hhvm/install_fastcgi.sh
==> default: * $ sudo /etc/init.d/hhvm restart
==> default: * (if using nginx)  $ sudo /etc/init.d/nginx restart
==> default: * (if using apache) $ sudo /etc/init.d/apache restart
==> default: * 
==> default: * Detailed FastCGI directions are online at:
==> default: * https://github.com/facebook/hhvm/wiki/FastCGI
==> default: * 
==> default: * If you're using HHVM to run web scripts, you probably want it to start at boot:
==> default: * $ sudo update-rc.d hhvm defaults
==> default: * 
==> default: * Running command-line scripts with HHVM requires no special setup:
==> default: * $ hhvm whatever.php
==> default: * 
==> default: * You can use HHVM for /usr/bin/php even if you have php-cli installed:
==> default: * $ sudo /usr/bin/update-alternatives --install /usr/bin/php php /usr/bin/hhvm 60
==> default: ********************************************************************
==> default: Setting up libpaper-utils (1.1.24+nmu2ubuntu3) ...
==> default: Processing triggers for libc-bin (2.19-10ubuntu2.3) ...
==> default:  * Restarting nginx nginx
==> default:    ...done.
==> default: php5-fpm stop/waiting
==> default: php5-fpm start/running, process 3135
```