### PR TITLE
Remove installing redis pecl extension

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -51,7 +51,7 @@ apt-get install -y php5-cli php5-dev php-pear \
 php5-mysqlnd php5-pgsql php5-sqlite \
 php5-apcu php5-json php5-curl php5-gd \
 php5-gmp php5-imap php5-mcrypt php5-xdebug \
-php5-memcached php5-redis
+php5-memcached
 
 # Make MCrypt Available
 


### PR DESCRIPTION
This looks to have been added from #2, but it doesn't work with Laravel since Redis is aliased by default and it collides with the package which also adds a Redis class and throws all kinds of fatal errors.

Does this work for anyone else?