### PR TITLE
Upload file bigger than 8M

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -114,6 +114,7 @@ sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/fpm/php.ini
 sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php5/fpm/php.ini
 sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php5/fpm/php.ini
 sed -i "s/upload_max_filesize = .*/upload_max_filesize = 100M/" /etc/php5/fpm/php.ini
+sed -i "s/post_max_size = .*/post_max_size = 100M/" /etc/php5/fpm/php.ini
 sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php5/fpm/php.ini
 
 echo "xdebug.remote_enable = 1" >> /etc/php5/fpm/conf.d/20-xdebug.ini


### PR DESCRIPTION
We already have `upload_max_filesize = 100M`, but we also need `post_max_size = 100M` too, otherwise we get a really bad `TokenMismatchException` which is really difficult to track. =)