### PR TITLE
Upgrading Node and NPM Version

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -18,7 +18,6 @@ apt-get install -y software-properties-common curl
 
 apt-add-repository ppa:nginx/stable -y
 apt-add-repository ppa:rwky/redis -y
-apt-add-repository ppa:chris-lea/node.js -y
 apt-add-repository ppa:ondrej/php5-5.6 -y
 
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
@@ -26,6 +25,8 @@ sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /
 
 curl -s https://packagecloud.io/gpg.key | sudo apt-key add -
 echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list
+
+curl --silent --location https://deb.nodesource.com/setup_0.12 | sudo bash -
 
 # Update Package Lists
 


### PR DESCRIPTION
Currently Homestead has the versions:

* Node 0.10.x
* NPM 1.x

Now with my change it ships with latest stable version of node and npm

* Node 0.12.x
* NPM 2.x

And this is the recommended way for installing node as we can see: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions