### PR TITLE
Increase xdebug.max_nesting_level to 256

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -122,7 +122,7 @@ sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php5/fpm/php.ini
 echo "xdebug.remote_enable = 1" >> /etc/php5/fpm/conf.d/20-xdebug.ini
 echo "xdebug.remote_connect_back = 1" >> /etc/php5/fpm/conf.d/20-xdebug.ini
 echo "xdebug.remote_port = 9000" >> /etc/php5/fpm/conf.d/20-xdebug.ini
-echo "xdebug.max_nesting_level = 250" >> /etc/php5/fpm/conf.d/20-xdebug.ini
+echo "xdebug.max_nesting_level = 256" >> /etc/php5/fpm/conf.d/20-xdebug.ini
 
 # Copy fastcgi_params to Nginx because they broke it on the PPA
 


### PR DESCRIPTION
Homestead is awesome, and it works well for Drupal too, however Drupal 8 requires xdebug.max_nesting_level to be 256 or higher.