### PR TITLE
Bump nesting level

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -122,7 +122,7 @@ sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php5/fpm/php.ini
 echo "xdebug.remote_enable = 1" >> /etc/php5/fpm/conf.d/20-xdebug.ini
 echo "xdebug.remote_connect_back = 1" >> /etc/php5/fpm/conf.d/20-xdebug.ini
 echo "xdebug.remote_port = 9000" >> /etc/php5/fpm/conf.d/20-xdebug.ini
-echo "xdebug.max_nesting_level = 256" >> /etc/php5/fpm/conf.d/20-xdebug.ini
+echo "xdebug.max_nesting_level = 512" >> /etc/php5/fpm/conf.d/20-xdebug.ini
 
 # Copy fastcgi_params to Nginx because they broke it on the PPA
 


### PR DESCRIPTION
If drupal needed 256, as soon as someone starts playing with packages and extensions, they're going to bust that limit.