### PR TITLE
Fix HHVM installation on Ubuntu 14.04 "Trusty" LTS

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -93,7 +93,7 @@ service nginx restart
 # Add The HHVM Key & Repository
 
 wget -O - http://dl.hhvm.com/conf/hhvm.gpg.key | apt-key add -
-echo deb http://dl.hhvm.com/ubuntu utopic main | tee /etc/apt/sources.list.d/hhvm.list
+echo deb http://dl.hhvm.com/ubuntu trusty main | tee /etc/apt/sources.list.d/hhvm.list
 apt-get update
 apt-get install -y hhvm
 


### PR DESCRIPTION
Homestead was downgraded to Ubuntu 14.04 "Trusty" LTS but this broke HHVM installation. It was referencing the wrong distribution repository.