### PR TITLE
Adds libnotify-bin package, so Gulp doesn't fail

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -35,7 +35,7 @@ apt-get update
 # Install Some Basic Packages
 
 apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev \
-make python2.7-dev python-pip re2c supervisor unattended-upgrades whois vim
+make python2.7-dev python-pip re2c supervisor unattended-upgrades whois vim libnotify-bin
 
 # Set My Timezone
 


### PR DESCRIPTION
Hello,

Thanks for the VM. It's great ! :smiley: 

When running `gulp` from within a Homestead VM, I get an error because the command `notify-send` does not exist. It seems like the `libnotify-bin` package is missing:
![selection_001](https://cloud.githubusercontent.com/assets/1234006/9704856/71eece18-54b4-11e5-8b19-fa0a71a3069d.png)

This won't enable you to get notifications when running `gulp` from within the VM, but at least the error will be gone.

Please let me know if you have any questions.

Best regards,
Conrad