### PR TITLE
Updated bento location with Parallels support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Run The Base Provisioning Script
   config.vm.provision 'shell', path: './scripts/update.sh'
   config.vm.provision :reload
-  # config.vm.provision 'shell', path: './scripts/vmware_tools.sh'
-  # config.vm.provision :reload
+  config.vm.provision 'shell', path: './scripts/vmware_tools.sh'
+  config.vm.provision :reload
   config.vm.provision 'shell', path: './scripts/provision.sh'
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Configure The Box
-  config.vm.box = 'chef/ubuntu-14.04'
+  config.vm.box = 'bento/ubuntu-14.04'
   config.vm.hostname = 'homestead'
 
   # Don't Replace The Default Key https://github.com/mitchellh/vagrant/pull/4707
@@ -19,6 +19,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.cpus = 2
   end
 
+  config.vm.provider :parallels do |v|
+    v.memory = 2048
+    v.cpus = 2
+    v.update_guest_tools = true
+  end
+
   # Configure Port Forwarding
   config.vm.network 'forwarded_port', guest: 80, host: 8000
   config.vm.network 'forwarded_port', guest: 3306, host: 33060
@@ -30,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Run The Base Provisioning Script
   config.vm.provision 'shell', path: './scripts/update.sh'
   config.vm.provision :reload
-  config.vm.provision 'shell', path: './scripts/vmware_tools.sh'
-  config.vm.provision :reload
+  # config.vm.provision 'shell', path: './scripts/vmware_tools.sh'
+  # config.vm.provision :reload
   config.vm.provision 'shell', path: './scripts/provision.sh'
 end

--- a/build.sh
+++ b/build.sh
@@ -30,3 +30,11 @@ cd ../../../../../
 ls -lh vmware_fusion.box
 vagrant destroy -f
 rm -rf .vagrant
+
+time vagrant up --provider parallels 2>&1 | tee parallels-build-output.log
+vagrant halt
+vagrant package --output parallels.box
+
+ls -lh parallels.box
+vagrant destroy -f
+rm -rf .vagrant


### PR DESCRIPTION
Chef has removed their previous Vagrant box repo, leaving an invalid link in settler. The new bento base boxes support the parallels provider. I made a few minor revisions to extend that support to settler.