### PR TITLE
Update Base Box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Configure The Box
-  config.vm.box = 'chef/ubuntu-14.04'
+  config.vm.box = 'bento/ubuntu-14.04'
   config.vm.hostname = 'homestead'
 
   # Don't Replace The Default Key https://github.com/mitchellh/vagrant/pull/4707


### PR DESCRIPTION
Our base box updated it's namespace, currently we get this error:

````
The box you're adding has a name different from the name you
requested. For boxes with metadata, you cannot override the name.
If you're adding a box using `vagrant box add`, don't specify
the `--name` parameter. If the box is being added via a Vagrantfile,
change the `config.vm.box` value to match the name below.

Requested name: chef/ubuntu-14.04
Actual name: bento/ubuntu-14.04
````

This fixes the issue...