### PR TITLE
Upgrading Node to v5

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -26,7 +26,7 @@ sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /
 curl -s https://packagecloud.io/gpg.key | apt-key add -
 echo "deb http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list
 
-curl --silent --location https://deb.nodesource.com/setup_4.x | bash -
+curl --silent --location https://deb.nodesource.com/setup_5.x | bash -
 
 # Update Package Lists
 


### PR DESCRIPTION
Version 4.2 is LTS, but Node 5 is already stable... not sure if you want to keep using LTS or not...