### PR TITLE
Upgraded mysql to 5.7

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Update Package List
 
 apt-get update
@@ -19,6 +21,10 @@ apt-get install -y software-properties-common curl
 apt-add-repository ppa:nginx/stable -y
 apt-add-repository ppa:rwky/redis -y
 apt-add-repository ppa:ondrej/php5-5.6 -y
+
+# gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
+apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5072E1F5
+sh -c 'echo "deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7" >> /etc/apt/sources.list.d/mysql.list'
 
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list'
@@ -186,9 +192,10 @@ apt-get install -y sqlite3 libsqlite3-dev
 
 # Install MySQL
 
-debconf-set-selections <<< "mysql-server mysql-server/root_password password secret"
-debconf-set-selections <<< "mysql-server mysql-server/root_password_again password secret"
-apt-get install -y mysql-server-5.6
+debconf-set-selections <<< "mysql-community-server mysql-community-server/data-dir select ''"
+debconf-set-selections <<< "mysql-community-server mysql-community-server/root-pass password secret"
+debconf-set-selections <<< "mysql-community-server mysql-community-server/re-root-pass password secret"
+apt-get install -y mysql-server
 
 # Configure MySQL Remote Access
 


### PR DESCRIPTION
@taylorotwell When I looked through the error logs there were a few issues, one was that the debian config commands were trying to be in interactive mode and two the name of the config keys changed.

I tested running `bash build.sh` and then importing the `virtualbox.box` file into vagrant and then running homestead `vagrant up` with my custom image and it is working for me.

We may want to document that flow in the readme to ensure future contributions are throughly tested.
```
bash build.sh
vagrant box add virtualbox.box --name homestead/test
// Set homestead.yaml box to homestead/test
// Run vagrant up from homestead dir
```
Now I get:
```
vagrant@homestead:~/Code$ mysql --version
mysql  Ver 14.14 Distrib 5.7.9, for Linux (x86_64) using  EditLine wrapper
```