### PR TITLE
Set default_password_lifetime to 0 (Never Expire)

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -200,6 +200,7 @@ apt-get install -y mysql-server
 # Configure MySQL Remote Access
 
 sed -i '/^bind-address/s/bind-address.*=.*/bind-address = 0.0.0.0/' /etc/mysql/my.cnf
+echo "default_password_lifetime = 0" >> /etc/mysql/my.cnf
 mysql --user="root" --password="secret" -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 service mysql restart
 


### PR DESCRIPTION
default_password_lifetime is 360 since MySQL 5.7.4
http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_default_password_lifetime

It will stop apps using MySQL 360 days later.

```bash
vagrant@homestead:~$ mysql -u homestead -p

mysql> UPDATE mysql.user SET password_last_changed = '2014-11-13 00:00:00' WHERE user = 'homestead'; 
Query OK, 2 rows affected (0.00 sec)
Rows matched: 2  Changed: 2  Warnings: 0

mysql> FLUSH PRIVILEGES;
Query OK, 0 rows affected (0.01 sec)

mysql> ^DBye


vagrant@homestead:~$ mysql -u homestead -p

mysql> SHOW DATABASES;
ERROR 1820 (HY000): You must reset your password using ALTER USER statement before executing this statement.

```