### PR TITLE
ppa:ondrej/php-7.0 is deprecated

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -20,7 +20,7 @@ apt-get install -y software-properties-common curl
 
 apt-add-repository ppa:nginx/development -y
 apt-add-repository ppa:chris-lea/redis-server -y
-apt-add-repository ppa:ondrej/php-7.0 -y
+apt-add-repository ppa:ondrej/php -y
 
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5072E1F5


### PR DESCRIPTION
This repository will be disabled in the future, please use ppa:ondrej/php as it has the same contents, PHP 5.6 as a added bonus now, and any future version of PHP in the future.