### PR TITLE
Fixed missing php-mcrypt extension

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -51,7 +51,7 @@ ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
 apt-get install -y --force-yes php7.0-cli php7.0-dev \
 php-pgsql php-sqlite3 php-gd php-apcu \
-php-curl php7.0-dev \
+php-curl php7.0-mcrypt \
 php-imap php-mysql php-memcached php7.0-readline php-xdebug
 
 # Install Composer


### PR DESCRIPTION
This should fix an issue with php mcrypt missing by default, according to https://laracasts.com/discuss/channels/general-discussion/use-of-undefined-constant-mcrypt-rijndael-128-assumed-mcrypt-rijndael-128/replies/136263

Also `php7.0-dev` was listed twice, so I removed one. No real problem here, just to note the change.

Greetings & keep up the awesome work.