### PR TITLE
Change initial provision upgrade command to dist-upgrade 

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,4 +14,4 @@ update-grub
 
 # Upgrade System Packages
 
-apt-get -y upgrade
+apt-get -y dist-upgrade


### PR DESCRIPTION
Maybe run dist-upgrade on first build provisions to get held back packages (such as new linux-kernel). I haven't tested it out myself yet. 