### PR TITLE
Execute command under vagrant user instead of root

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -62,7 +62,7 @@ mv composer.phar /usr/local/bin/composer
 
 # Add Composer Global Bin To Path
 
-printf "\nPATH=\"$(composer config -g home 2>/dev/null)/vendor/bin:\$PATH\"\n" | tee -a /home/vagrant/.profile
+printf "\nPATH=\"$(sudo su - vagrant -c 'composer config -g home 2>/dev/null')/vendor/bin:\$PATH\"\n" | tee -a /home/vagrant/.profile
 
 # Install Laravel Envoy & Installer
 


### PR DESCRIPTION
This to make sure that the line is added to .profile as "/home/vagrant/.config/composer/vendor/bin" or whatever composer home directory under vagrant user,  the current is adding it as /root not vagrant.