### PR TITLE
Re-add xdebug config settings

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -105,6 +105,11 @@ update-rc.d hhvm defaults
 
 # Setup Some PHP-FPM Options
 
+echo "xdebug.remote_enable = 1" >> /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+echo "xdebug.remote_connect_back = 1" >> /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+echo "xdebug.remote_port = 9000" >> /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+echo "xdebug.max_nesting_level = 512" >> /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+
 sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/7.0/fpm/php.ini
 sed -i "s/display_errors = .*/display_errors = On/" /etc/php/7.0/fpm/php.ini
 sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php/7.0/fpm/php.ini


### PR DESCRIPTION
Re-enables the settings needed to make xdebug work.

They were removed a few months ago when PHP-7 had no xdebug support. Whilst [xdebug is now installed with the latest version of homestead](https://github.com/laravel/settler/commit/f4ca4a05a5eceb4ab284fa01d98ee7982fa806d7), the settings to activate it were never added back. This PR fixes that.

Commit that removed this originally: https://github.com/laravel/settler/commit/fcdca5ffba5b8abcd3b9b4e0d13a213372d76dbc

