### PR TITLE
Fixes composer being very slow due to xdebug being loaded on cli.

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -113,6 +113,10 @@ sed -i "s/upload_max_filesize = .*/upload_max_filesize = 100M/" /etc/php/7.0/fpm
 sed -i "s/post_max_size = .*/post_max_size = 100M/" /etc/php/7.0/fpm/php.ini
 sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php/7.0/fpm/php.ini
 
+# Stop xdebug slowing composer when run from command line.
+
+sudo phpdismod -s cli xdebug
+
 # Copy fastcgi_params to Nginx because they broke it on the PPA
 
 cat > /etc/nginx/fastcgi_params << EOF


### PR DESCRIPTION
This is a **separate issue** to https://github.com/laravel/settler/pull/77

When a default machine is created, xdebug is installed and defaults to being enabled for php-fpm as well as the cli.

This means that when we try and run `composer install` or `composer update`, it slows down a system considerably, and presents us with a warning.

By disabling xdebug being loaded for the cli **only ** we can still benefit from using xdebug with homestead but massively improve the speed of composer and removed the warning.

![image](https://cloud.githubusercontent.com/assets/2513663/14845711/ebd2b43c-0c57-11e6-9cfd-f8d9e0db009d.png)

Again, just for clarity this has no relation to https://github.com/laravel/settler/pull/77
