### PR TITLE
Upgrade nodejs to v6

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -32,7 +32,7 @@ sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /
 curl -s https://packagecloud.io/gpg.key | apt-key add -
 echo "deb http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list
 
-curl --silent --location https://deb.nodesource.com/setup_5.x | bash -
+curl --silent --location https://deb.nodesource.com/setup_6.x | bash -
 
 # Update Package Lists
 


### PR DESCRIPTION
Node.js v5 will be unsupported by the end of this month. V6 is the "current" branch and v6.x will become the new LTS release [in october](https://github.com/nodejs/LTS#lts_schedule).