### PR TITLE
:sparkles: :ambulance: :snowflake: Add port autocorrection and re-enable VMWare box packaging

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,10 +20,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Configure Port Forwarding
-  config.vm.network 'forwarded_port', guest: 80, host: 8000
-  config.vm.network 'forwarded_port', guest: 3306, host: 33060
-  config.vm.network 'forwarded_port', guest: 5432, host: 54320
-  config.vm.network 'forwarded_port', guest: 35729, host: 35729
+  config.vm.network 'forwarded_port', guest: 80, host: 8000, auto_correct: true
+  config.vm.network 'forwarded_port', guest: 3306, host: 33060, auto_correct: true
+  config.vm.network 'forwarded_port', guest: 5432, host: 54320, auto_correct: true
+  config.vm.network 'forwarded_port', guest: 35729, host: 35729, auto_correct: true
 
   config.vm.synced_folder './', '/vagrant', disabled: true
 

--- a/build.sh
+++ b/build.sh
@@ -15,19 +15,19 @@ ls -lh virtualbox.box
 vagrant destroy -f
 rm -rf .vagrant
 
-# time vagrant up --provider vmware_fusion 2>&1 | tee vmware-build-output.log
-# vagrant halt
+ time vagrant up --provider vmware_fusion 2>&1 | tee vmware-build-output.log
+ vagrant halt
 
-# # defrag disk (assumes running on osx)
-# /Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager -d .vagrant/machines/default/vmware_fusion/*-*-*-*-*/disk.vmdk
-# # shrink disk (assumes running on osx)
-# /Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager -k .vagrant/machines/default/vmware_fusion/*-*-*-*-*/disk.vmdk
-# # 'vagrant package' does not work with vmware boxes (http://docs.vagrantup.com/v2/vmware/boxes.html)
-# cd .vagrant/machines/default/vmware_fusion/*-*-*-*-*/
-# rm -f vmware*.log
-# tar cvzf ../../../../../vmware_fusion.box *
-# cd ../../../../../
+ # defrag disk (assumes running on osx)
+ /Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager -d .vagrant/machines/default/vmware_fusion/*-*-*-*-*/disk.vmdk
+ # shrink disk (assumes running on osx)
+ /Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager -k .vagrant/machines/default/vmware_fusion/*-*-*-*-*/disk.vmdk
+ # 'vagrant package' does not work with vmware boxes (http://docs.vagrantup.com/v2/vmware/boxes.html)
+ cd .vagrant/machines/default/vmware_fusion/*-*-*-*-*/
+ rm -f vmware*.log
+ tar cvzf ../../../../../vmware_fusion.box *
+ cd ../../../../../
 
-# ls -lh vmware_fusion.box
-# vagrant destroy -f
-# rm -rf .vagrant
+ ls -lh vmware_fusion.box
+ vagrant destroy -f
+ rm -rf .vagrant


### PR DESCRIPTION
* VMWare likes to complain about ports listening when they're not actually in use on the host. 
    * Probably something it doesn't like with the vboxnet devices. 
    * Setting autocorrect is a workaround for the port collisions that may happen. 
* Re-enabled VMWare box packaging in the build script.