### PR TITLE
Clean up caches

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -265,6 +265,11 @@ service mailhog start
 systemctl enable supervisor.service
 service supervisor start
 
+# Clean up
+
+apt-get -y autoremove
+apt-get -y clean
+
 # Enable Swap Memory
 
 /bin/dd if=/dev/zero of=/var/swap.1 bs=1M count=1024

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -265,7 +265,7 @@ service mailhog start
 systemctl enable supervisor.service
 service supervisor start
 
-# Clean up
+# Clean Up
 
 apt-get -y autoremove
 apt-get -y clean


### PR DESCRIPTION
By purging apt caches and unused packages, the box size can be reduced.