### PR TITLE
reload systemd files before enabling mailhog

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -235,6 +235,7 @@ ExecStart=/usr/bin/env /usr/local/bin/mailhog > /dev/null 2>&1 &
 WantedBy=multi-user.target
 EOL
 
+systemctl daemon-reload
 systemctl enable mailhog
 
 # Configure Supervisor


### PR DESCRIPTION
The service is still disabled because the systemd service file can not be found.
```
root@homestead:~# systemctl status mailhog -l
â—� mailhog.service - Mailhog
   Loaded: loaded (/etc/systemd/system/mailhog.service; disabled; vendor preset: enabled)
   Active: inactive (dead)
```
As you can see the service is still disabled. Reloading the systemd daemon before enabling the service fixes this.
