### PR TITLE
update NPM

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -235,6 +235,7 @@ groups vagrant
 # Install Node
 
 apt-get install -y nodejs
+/usr/bin/npm install -g npm
 /usr/bin/npm install -g gulp
 /usr/bin/npm install -g bower
 /usr/bin/npm install -g yarn


### PR DESCRIPTION
nodejs ships with an older version of NPM (at the time of this PR, v3).  The current stable release of NPM is v5.  This change will force NPM to be updated.