### PR TITLE
Set a hold on openssl to prevent ondrej/php from updating it.

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -6,6 +6,11 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 
+# Hold openssl from updating to prevent shared object conflicts
+
+apt-mark hold openssl
+apt-mark hold libssl-dev
+
 # Update System Packages
 apt-get -y upgrade
 


### PR DESCRIPTION
**Note: This fix is not fully tested.**

When installing a package that needs openssl/libssl-dev it can share 2 versions of openssl in its shared objects. This is because the ondrej/php wants to update openssl to 1.1 despite many parts of ubuntu needing 1.0.

Because I have not tested this fix building the full structure of settler > build box > install custom homestead, I have not been able to check if it leads to any issue with php/curl (witch I assume is the reason ondrej/php wants it). Though testing what I could I didn't find any problems.