### PR TITLE
zsh: add .profile sourcing

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -404,6 +404,7 @@ mv wp-cli.phar /usr/local/bin/wp
 git clone git://github.com/robbyrussell/oh-my-zsh.git /home/vagrant/.oh-my-zsh
 cp /home/vagrant/.oh-my-zsh/templates/zshrc.zsh-template /home/vagrant/.zshrc
 printf "\nsource ~/.bash_aliases\n" | tee -a /home/vagrant/.zshrc
+printf "\nsource ~/.profile\n" | tee -a /home/vagrant/.zshrc
 chown -R vagrant:vagrant /home/vagrant/.oh-my-zsh
 chown vagrant:vagrant /home/vagrant/.zshrc
 


### PR DESCRIPTION
the ENV variables are not working for zsh when running `php artisan ....`
https://superuser.com/a/892248/168712
zsh will try to load .zprofile, not .profile.  We can just source it and then both zsh and bash will work.