### PR TITLE
Update provision.sh

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -282,7 +282,7 @@ groups vagrant
 
 apt-get install -y nodejs
 /usr/bin/npm install -g npm
-/usr/bin/npm install -g gulp
+/usr/bin/npm install -g gulp-cli
 /usr/bin/npm install -g bower
 /usr/bin/npm install -g yarn
 /usr/bin/npm install -g grunt-cli


### PR DESCRIPTION
Change global install of `gulp` to use `gulp-cl`i as [recommended by Gulp's docs](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md). 

This avoids any conflicts with per-project versions of Gulp, especially with `gulp@next` now available.