### PR TITLE
Don't enable Z-Ray for PHP CLI

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -334,10 +334,9 @@ service postgresql restart
 
 apt-get install -y blackfire-agent blackfire-php
 
-# Install Zend Z-Ray
+# Install Zend Z-Ray (for FPM only, not CLI)
 
 sudo wget http://repos.zend.com/zend-server/early-access/ZRay-Homestead/zray-standalone-php72.tar.gz -O - | sudo tar -xzf - -C /opt
-sudo ln -sf /opt/zray/zray.ini /etc/php/7.2/cli/conf.d/zray.ini
 sudo ln -sf /opt/zray/zray.ini /etc/php/7.2/fpm/conf.d/zray.ini
 sudo ln -sf /opt/zray/lib/zray.so /usr/lib/php/20170718/zray.so
 sudo chown -R vagrant:vagrant /opt/zray


### PR DESCRIPTION
CLI scripts were running out of memory. Narrowed it down to Zend Z-Ray.

Fixes https://bugs.php.net/bug.php?id=76053 and https://www.reddit.com/r/PHPhelp/comments/8295j6/potential_memory_leak_in_pdo_using_722/