### PR TITLE
Move php-xdebug php-pear to PHP7.2 install section

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -59,7 +59,8 @@ php7.2-pgsql php7.2-sqlite3 php7.2-gd \
 php7.2-curl php7.2-memcached \
 php7.2-imap php7.2-mysql php7.2-mbstring \
 php7.2-xml php7.2-zip php7.2-bcmath php7.2-soap \
-php7.2-intl php7.2-readline
+php7.2-intl php7.2-readline \
+php-xdebug php-pear
 
 # PHP 7.1
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
@@ -68,7 +69,7 @@ php7.1-pgsql php7.1-sqlite3 php7.1-gd \
 php7.1-curl php7.1-memcached \
 php7.1-imap php7.1-mysql php7.1-mbstring \
 php7.1-xml php7.1-zip php7.1-bcmath php7.1-soap \
-php7.1-intl php7.1-readline php-xdebug php-pear
+php7.1-intl php7.1-readline
 
 # PHP 7.0
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \


### PR DESCRIPTION
Keeping `php-xdebug` and  `php-pear` with the latest release.