### PR TITLE
Install libpng-dev for laravel-mix/pngquant-bin

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -43,7 +43,7 @@ curl --silent --location https://deb.nodesource.com/setup_8.x | bash -
 
 # Install Some Basic Packages
 
-apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev ntp unzip \
+apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev libpng-dev ntp unzip \
 make python2.7-dev python-pip re2c supervisor unattended-upgrades whois vim libnotify-bin \
 pv cifs-utils mcrypt bash-completion zsh
 


### PR DESCRIPTION
`pngquant-bin` is in the dependency tree for Laravel Mix and requires the `libpng-dev` package.

This is the error I got during an `npm run dev`:

```
Error: pngquant failed to build, make sure that libpng-dev is installed
```