### PR TITLE
Add links to Vagrant box and Homestead documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,14 @@
 # Laravel Settler
 
-The scripts that build the Laravel Homestead development environment.
+The scripts that build the Laravel Homestead development environment. 
+
+End result can be found at https://app.vagrantup.com/laravel/boxes/homestead
 
 ## Usage
 
-You probably don't want this repo.
+You probably don't want this repo, follow instructions at https://laravel.com/docs/homestead instead.
+
+If you know what you are doing:
 
 * Clone [chef/bento](https://github.com/chef/bento) into same top level folder as this repo.
 * Run `./bin/copy-to-bento.sh`


### PR DESCRIPTION
Tiny suggestion to small changes to README, so it's clearer what this is and what it is for.