### PR TITLE
Ldap, php-config, phpize 7.2

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -89,6 +89,8 @@ php5.6-xml php5.6-zip php5.6-bcmath php5.6-soap \
 php5.6-intl php5.6-readline php5.6-mcrypt
 
 update-alternatives --set php /usr/bin/php7.2
+update-alternatives --set php-config /usr/bin/php-config7.2
+update-alternatives --set phpize /usr/bin/phpize7.2
 
 # Install Composer
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -58,7 +58,7 @@ php7.2-pgsql php7.2-sqlite3 php7.2-gd \
 php7.2-curl php7.2-memcached \
 php7.2-imap php7.2-mysql php7.2-mbstring \
 php7.2-xml php7.2-zip php7.2-bcmath php7.2-soap \
-php7.2-intl php7.2-readline \
+php7.2-intl php7.2-readline php7.2-ldap \
 php-xdebug php-pear
 
 # PHP 7.1


### PR DESCRIPTION
Adding the ldap package (alleviates problem with prompting the user for which configuration file to keep). Also adding php-config and phpize update-alternative settings; previous (and maybe the current) version of Homestead (6.0.0, 6.10) has been provisioned with an version of php7.2-dev that no longer exists in the ppa repo and requires an apt-get update to locate the correct package, having explicit settings for php-config and phpize would of caused an error message when the dev libraries are not available.