### PR TITLE
Remove installation of libssl1.0-dev

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -446,7 +446,7 @@ service supervisor start
 apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-keys 09617FD37CC06B54
 echo "deb https://dist.crystal-lang.org/apt crystal main" | tee /etc/apt/sources.list.d/crystal.list
 apt-get update
-apt-get install -y crystal libssl1.0-dev
+apt-get install -y crystal
 
 # Install Lucky Framework for Crystal
 


### PR DESCRIPTION
I have noticed that while building the image it does the following (simplified):

```bash
# ...
apt-get install -y php<version>-dev ...  # This pulls in libssl-dev
# ...
apt-get install -y crystal libssl1.0-dev # This removes libssl-dev and all php<version>-dev packages
# ...
apt-get -y install libssl-dev ... # Ruby stuff, removes libssl1.0-dev
```

At the end of all this playing around with `libssl-dev` vs `libssl1.0-dev`, only  `libssl-dev` remains installed and all `php<version>-dev` packages are not.

This PR just deletes the `libssl1.0-dev` from the installation line of `crystal` (the package itself recommends `libssl-dev`, not `libssl1.0-dev`.