### PR TITLE
Run `rbenv rehash` after installing rails gem

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -477,6 +477,7 @@ rbenv install 2.6.1
 rbenv global 2.6.1
 apt-get -y install ruby`ruby -e 'puts RUBY_VERSION[/\d+\.\d+/]'`-dev
 gem install rails -v 5.2.2
+rbenv rehash
 
 # Install socket-wrench Repo
 #


### PR DESCRIPTION
This will make the rails executable use 2.6.1

https://gorails.com/setup/ubuntu/18.04#rails

Fixes laravel/homestead#1067