### PR TITLE
Link instead of copy provision.sh

### DIFF
--- a/bin/copy-to-bento.sh
+++ b/bin/copy-to-bento.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-/bin/cp -rf scripts/provision.sh ../bento/ubuntu/scripts/homestead.sh

--- a/bin/link-to-bento.sh
+++ b/bin/link-to-bento.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash -x
+/bin/ln scripts/provision.sh ../bento/ubuntu/scripts/homestead.sh

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ You probably don't want this repo, follow instructions at https://laravel.com/do
 If you know what you are doing:
 
 * Clone [chef/bento](https://github.com/chef/bento) into same top level folder as this repo.
-* Run `./bin/copy-to-bento.sh`
+* Run `./bin/link-to-bento.sh`
 * Run `cd ../bento` and work there for the remainder.
 * Replace `scripts/cleanup.sh` with `scripts/homestead.sh` in file `ubuntu/ubuntu-18.04-amd64.json`
 * Follow normal [Packer](https://www.packer.io/) practice of building `ubuntu/ubuntu-18.04-amd64.json`

--- a/readme.md
+++ b/readme.md
@@ -12,5 +12,6 @@ If you know what you are doing:
 
 * Clone [chef/bento](https://github.com/chef/bento) into same top level folder as this repo.
 * Run `./bin/copy-to-bento.sh`
+* Run `cd ../bento` and work there for the remainder.
 * Replace `scripts/cleanup.sh` with `scripts/homestead.sh` in file `ubuntu/ubuntu-18.04-amd64.json`
 * Follow normal [Packer](https://www.packer.io/) practice of building `ubuntu/ubuntu-18.04-amd64.json`


### PR DESCRIPTION
Using a hard link means that you don't have to manually copy `provision.sh` when editing. macOS (and BSD?) don't support `cp -l` so I'm using `ln` instead.