### PR TITLE
Install php7.x-phpdbg by default

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -36,27 +36,31 @@ ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
 php7.3-cli php7.3-dev php7.3-pgsql php7.3-sqlite3 php7.3-gd php7.3-curl php7.3-imap php7.3-mysql \
 php7.3-mbstring php7.3-xml php7.3-zip php7.3-bcmath php7.3-soap php7.3-intl php7.3-readline php7.3-ldap \
-php-xdebug php-memcached php-pear
+php7.3-phpdbg php-xdebug php-memcached php-pear
 
 # PHP 7.2
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
 php7.2-cli php7.2-dev php7.2-pgsql php7.2-sqlite3 php7.2-gd php7.2-curl php7.2-imap php7.2-mysql \
-php7.2-mbstring php7.2-xml php7.2-zip php7.2-bcmath php7.2-soap php7.2-intl php7.2-readline php7.2-ldap
+php7.2-mbstring php7.2-xml php7.2-zip php7.2-bcmath php7.2-soap php7.2-intl php7.2-readline php7.2-ldap \
+php7.2-phpdbg
 
 # PHP 7.1
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
 php7.1-cli php7.1-dev php7.1-pgsql php7.1-sqlite3 php7.1-gd php7.1-curl php7.1-imap php7.1-mysql \
-php7.1-mbstring php7.1-xml php7.1-zip php7.1-bcmath php7.1-soap php7.1-intl php7.1-readline php7.1-ldap
+php7.1-mbstring php7.1-xml php7.1-zip php7.1-bcmath php7.1-soap php7.1-intl php7.1-readline php7.1-ldap \
+php7.1-phpdbg
 
 # PHP 7.0
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
 php7.0-cli php7.0-dev php7.0-pgsql php7.0-sqlite3 php7.0-gd php7.0-curl php7.0-imap php7.0-mysql \
-php7.0-mbstring php7.0-xml php7.0-zip php7.0-bcmath php7.0-soap php7.0-intl php7.0-readline php7.0-ldap
+php7.0-mbstring php7.0-xml php7.0-zip php7.0-bcmath php7.0-soap php7.0-intl php7.0-readline php7.0-ldap \
+php7.0-phpdbg
 
 # PHP 5.6
 apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
 php5.6-cli php5.6-dev php5.6-pgsql php5.6-sqlite3 php5.6-gd php5.6-curl php5.6-imap php5.6-mysql \
-php5.6-mbstring php5.6-xml php5.6-zip php5.6-bcmath php5.6-soap php5.6-intl php5.6-readline php5.6-ldap
+php5.6-mbstring php5.6-xml php5.6-zip php5.6-bcmath php5.6-soap php5.6-intl php5.6-readline php5.6-ldap \
+php5.6-phpdbg
 
 update-alternatives --set php /usr/bin/php7.3
 update-alternatives --set php-config /usr/bin/php-config7.3


### PR DESCRIPTION
This PR adds [phpdbg](https://www.php.net/manual/en/book.phpdbg.php) to Homestead by default.

The module is installed for PHP version 7.3, 7.2, 7.1, 7.0, and 5.6.

Fixes laravel/homestead#1222.