### PR TITLE
Update Redis to version 5

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -17,6 +17,7 @@ apt-get install -y software-properties-common curl
 
 apt-add-repository ppa:nginx/development -y
 apt-add-repository ppa:ondrej/php -y
+apt-add-repository ppa:chris-lea/redis-server -y
 
 curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 


### PR DESCRIPTION
This is what I found on a Forge deployed server:

![image](https://user-images.githubusercontent.com/516807/66355038-5b3bf680-e92c-11e9-94b8-48d79b8922c8.png)

https://launchpad.net/~chris-lea/+archive/ubuntu/redis-server

![image](https://user-images.githubusercontent.com/516807/66355106-94746680-e92c-11e9-817a-90d9c20716f9.png)

Not sure this is everything there is to do for pull request 🤔

Current version is 5.0.6