### PR TITLE
explicitly set spark-installer version

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -89,7 +89,7 @@ sudo su vagrant <<'EOF'
 /usr/local/bin/composer global require "laravel/envoy=^1.6"
 /usr/local/bin/composer global require "laravel/installer=^2.1"
 /usr/local/bin/composer global require "laravel/lumen-installer=^1.1"
-/usr/local/bin/composer global require "laravel/spark-installer=dev-master"
+/usr/local/bin/composer global require "laravel/spark-installer=^3.1"
 EOF
 
 # Set Some PHP CLI Settings


### PR DESCRIPTION
it looks like previously this was switched from `~2.0` to `dev-master`, maybe because there was a needed feature that wasn't released?

anyway, now we're up to version 3, so unless there's a reason we need dev-master, switch back?

(super confident PR, right?)