### PR TITLE
Replace NTP with Chrony

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -31,7 +31,7 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 apt-get update
 
 # Install Some Basic Packages
-apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev libpng-dev ntp unzip make python2.7-dev \
+apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev libpng-dev chrony unzip make python2.7-dev \
 python-pip re2c supervisor unattended-upgrades whois vim libnotify-bin pv cifs-utils mcrypt bash-completion zsh \
 graphviz avahi-daemon tshark imagemagick
 
@@ -528,6 +528,9 @@ dpkg --list \
 
 # Delete obsolete networking
 apt-get -y purge ppp pppconfig pppoeconf
+
+# Configure chronyd to fix clock-drift when VM-host sleeps/hibernates.
+sed -i "s/^makestep.*/makestep 1 -1/" /etc/chrony/chrony.conf
 
 # Delete oddities
 apt-get -y purge popularity-contest installation-report command-not-found command-not-found-data friendly-recovery \


### PR DESCRIPTION
NTP does not handle the Sleep and Hibernate states on the *host* gracefully;
the clock on the guest becomes stale and is not updated regularly (if ever).

Replacing NTP with Chrony fixes the issue, provided chronyd is configured
to allow unlimited catching-up via "makestep 1 -1" (the second value
represents unlimited catch-up, which is necessary when the host has been
sleeping or hibernating for any period of time longer than a few seconds).

Resolves https://github.com/laravel/homestead/issues/1300