### PR TITLE
add all the missing extensions for PHP 7.3

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -39,12 +39,12 @@ graphviz avahi-daemon tshark imagemagick
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
 # Install PHP Stuffs
-# Current PHP
+# PHP 7.3
 apt-get install -y --allow-change-held-packages \
 php7.3 php7.3-bcmath php7.3-bz2 php7.3-cgi php7.3-cli php7.3-common php7.3-curl php7.3-dba php7.3-dev \
-php7.3-enchant php7.3-fpm php7.3-gd php7.3-gmp php7.3-imap php7.3-interbase php7.3-intl php7.3-json php7.3-ldap \
-php7.3-mbstring php7.3-mysql php7.3-odbc php7.3-opcache php7.3-pgsql php7.3-phpdbg php7.3-pspell php7.3-readline \
-php7.3-recode php7.3-snmp php7.3-soap php7.3-sqlite3 php7.3-sybase php7.3-tidy php7.3-xml php7.3-xmlrpc php7.3-xsl \
+php7.3-enchant php7.3-fpm php7.3-gd php7.3-gmp php7.3-imagick php7.3-imap php7.3-interbase php7.3-intl php7.3-json php7.3-ldap \
+php7.3-mbstring php7.3-memcached php7.3-mysql php7.3-odbc php7.3-opcache php7.3-pear php7.3-pgsql php7.3-phpdbg php7.3-pspell php7.3-readline \
+php7.3-recode php7.3-redis php7.3-snmp php7.3-soap php7.3-sqlite3 php7.3-sybase php7.3-tidy php7.3-xdebug php7.3-xml php7.3-xmlrpc php7.3-xsl \
 php7.3-zip
 
 # PHP 7.4


### PR DESCRIPTION
I went back and looked at #210 which seems to be the root of the missing extensions.  I double checked **all** the versions of PHP and 7.3 was the only one with missing extensions.

- imagick
- memcached
- pear
- redis
- xdebug