### PR TITLE
Add Git LFS plugin

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -31,7 +31,7 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 apt-get update
 
 # Install Some Basic Packages
-apt-get install -y build-essential dos2unix gcc git libmcrypt4 libpcre3-dev libpng-dev chrony unzip make python2.7-dev \
+apt-get install -y build-essential dos2unix gcc git git-lfs libmcrypt4 libpcre3-dev libpng-dev chrony unzip make python2.7-dev \
 python-pip re2c supervisor unattended-upgrades whois vim libnotify-bin pv cifs-utils mcrypt bash-completion zsh \
 graphviz avahi-daemon tshark imagemagick
 


### PR DESCRIPTION
Adds the Git LFS plugin.

I chose not to do the full system install in case developers didn't want that enabled by default. Users can choose how they want to setup LFS once they've built their Homestead VM with Vagrant.