### PR TITLE
remove Lumen installer

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -101,7 +101,6 @@ sudo su vagrant <<'EOF'
 /usr/local/bin/composer global require hirak/prestissimo
 /usr/local/bin/composer global require "laravel/envoy=^2.0"
 /usr/local/bin/composer global require "laravel/installer=^3.0.1"
-/usr/local/bin/composer global require "laravel/lumen-installer=^1.1"
 /usr/local/bin/composer global require "laravel/spark-installer=dev-master"
 /usr/local/bin/composer global require "slince/composer-registry-manager=^2.0"
 EOF


### PR DESCRIPTION
Package laravel/lumen-installer is abandoned.

The documentation now recommends using `composer create-project` for installation.

https://lumen.laravel.com/docs/7.x#installing-lumen