### PR TITLE
Revert Xdebug config to 2 for old PHP versions

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -231,21 +231,21 @@ echo "xdebug.client_port = 9003" >> /etc/php/7.2/mods-available/xdebug.ini
 echo "xdebug.max_nesting_level = 512" >> /etc/php/7.2/mods-available/xdebug.ini
 echo "opcache.revalidate_freq = 0" >> /etc/php/7.2/mods-available/opcache.ini
 
-echo "xdebug.mode = debug" >> /etc/php/7.1/mods-available/xdebug.ini
-echo "xdebug.discover_client_host = true" >> /etc/php/7.1/mods-available/xdebug.ini
-echo "xdebug.client_port = 9003" >> /etc/php/7.1/mods-available/xdebug.ini
+echo "xdebug.remote_enable = 1" >> /etc/php/7.1/mods-available/xdebug.ini
+echo "xdebug.remote_connect_back = 1" >> /etc/php/7.1/mods-available/xdebug.ini
+echo "xdebug.remote_port = 9000" >> /etc/php/7.1/mods-available/xdebug.ini
 echo "xdebug.max_nesting_level = 512" >> /etc/php/7.1/mods-available/xdebug.ini
 echo "opcache.revalidate_freq = 0" >> /etc/php/7.1/mods-available/opcache.ini
 
-echo "xdebug.mode = debug" >> /etc/php/7.0/mods-available/xdebug.ini
-echo "xdebug.discover_client_host = true" >> /etc/php/7.0/mods-available/xdebug.ini
-echo "xdebug.client_port = 9003" >> /etc/php/7.0/mods-available/xdebug.ini
+echo "xdebug.remote_enable = 1" >> /etc/php/7.0/mods-available/xdebug.ini
+echo "xdebug.remote_connect_back = 1" >> /etc/php/7.0/mods-available/xdebug.ini
+echo "xdebug.remote_port = 9000" >> /etc/php/7.0/mods-available/xdebug.ini
 echo "xdebug.max_nesting_level = 512" >> /etc/php/7.0/mods-available/xdebug.ini
 echo "opcache.revalidate_freq = 0" >> /etc/php/7.0/mods-available/opcache.ini
 
-echo "xdebug.mode = debug" >> /etc/php/5.6/mods-available/xdebug.ini
-echo "xdebug.discover_client_host = true" >> /etc/php/5.6/mods-available/xdebug.ini
-echo "xdebug.client_port = 9003" >> /etc/php/5.6/mods-available/xdebug.ini
+echo "xdebug.remote_enable = 1" >> /etc/php/5.6/mods-available/xdebug.ini
+echo "xdebug.remote_connect_back = 1" >> /etc/php/5.6/mods-available/xdebug.ini
+echo "xdebug.remote_port = 9000" >> /etc/php/5.6/mods-available/xdebug.ini
 echo "xdebug.max_nesting_level = 512" >> /etc/php/5.6/mods-available/xdebug.ini
 echo "opcache.revalidate_freq = 0" >> /etc/php/5.6/mods-available/opcache.ini
 


### PR DESCRIPTION
Xdebug 3 not compatible and not installed for PHP 5.6, 7.0, and 7.1

Partially reverts #228

<details>
 <summary>Versions</summary>

- PHP 8.0: Xdebug 3.0.2
- PHP 7.4: Xdebug 3.0.2
- PHP 7.3: Xdebug 3.0.2
- PHP 7.2: Xdebug 3.0.2
- PHP 7.1: Xdebug 2.9.8
- PHP 7.0: Xdebug 2.8.1
- PHP 5.6: Xdebug 2.5.5
</details>
