### PR TITLE
Add missing `php-imagick` extensions

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -74,7 +74,7 @@ else
   php5.6-fpm php5.6-gd php5.6-gmp php5.6-imap php5.6-interbase php5.6-intl php5.6-json php5.6-ldap php5.6-mbstring \
   php5.6-mcrypt php5.6-mysql php5.6-odbc php5.6-opcache php5.6-pgsql php5.6-phpdbg php5.6-pspell php5.6-readline \
   php5.6-recode php5.6-snmp php5.6-soap php5.6-sqlite3 php5.6-sybase php5.6-tidy php5.6-xml php5.6-xmlrpc php5.6-xsl \
-  php5.6-zip php5.6-memcached php5.6-redis
+  php5.6-zip php5.6-imagick php5.6-memcached php5.6-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/5.6/cli/php.ini
@@ -117,7 +117,7 @@ else
   php7.0-fpm php7.0-gd php7.0-gmp php7.0-imap php7.0-interbase php7.0-intl php7.0-json php7.0-ldap php7.0-mbstring \
   php7.0-mcrypt php7.0-mysql php7.0-odbc php7.0-opcache php7.0-pgsql php7.0-phpdbg php7.0-pspell php7.0-readline \
   php7.0-recode php7.0-snmp php7.0-soap php7.0-sqlite3 php7.0-sybase php7.0-tidy php7.0-xml php7.0-xmlrpc php7.0-xsl \
-  php7.0-zip php7.0-memcached php7.0-redis
+  php7.0-zip php7.0-imagick php7.0-memcached php7.0-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/7.0/cli/php.ini
@@ -159,7 +159,7 @@ else
   php7.1-fpm php7.1-gd php7.1-gmp php7.1-imap php7.1-interbase php7.1-intl php7.1-json php7.1-ldap php7.1-mbstring \
   php7.1-mcrypt php7.1-mysql php7.1-odbc php7.1-opcache php7.1-pgsql php7.1-phpdbg php7.1-pspell php7.1-readline \
   php7.1-recode php7.1-snmp php7.1-soap php7.1-sqlite3 php7.1-sybase php7.1-tidy php7.1-xdebug php7.1-xml php7.1-xmlrpc \
-  php7.1-xsl php7.1-zip php7.1-memcached php7.1-redis
+  php7.1-xsl php7.1-zip php7.1-imagick php7.1-memcached php7.1-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/7.1/cli/php.ini
@@ -201,7 +201,7 @@ else
   php7.2-mbstring php7.2-phpdbg php7.2-soap php7.2-sybase php7.2-xsl php7.2-zip php7.2-cgi php7.2-cli php7.2-common \
   php7.2-curl php7.2-dev php7.2-gd php7.2-gmp php7.2-json php7.2-ldap php7.2-mysql php7.2-odbc php7.2-opcache \
   php7.2-pgsql php7.2-pspell php7.2-readline php7.2-recode php7.2-snmp php7.2-sqlite3 php7.2-tidy php7.2-xdebug \
-  php7.2-xml php7.2-xmlrpc php7.2-memcached php7.2-redis
+  php7.2-xml php7.2-xmlrpc php7.2-imagick php7.2-memcached php7.2-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/7.2/cli/php.ini
@@ -244,7 +244,7 @@ else
   php7.3-fpm php7.3-gd php7.3-gmp php7.3-imap php7.3-interbase php7.3-intl php7.3-json php7.3-ldap php7.3-mbstring \
   php7.3-mysql php7.3-odbc php7.3-opcache php7.3-pgsql php7.3-phpdbg php7.3-pspell php7.3-readline php7.3-recode \
   php7.3-snmp php7.3-soap php7.3-sqlite3 php7.3-sybase php7.3-tidy php7.3-xdebug php7.3-xml php7.3-xmlrpc php7.3-xsl \
-  php7.3-zip php7.3-memcached php7.3-redis
+  php7.3-zip php7.3-imagick php7.3-memcached php7.3-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/7.3/cli/php.ini
@@ -286,7 +286,7 @@ else
   php7.4-enchant php7.4-fpm php7.4-gd php7.4-gmp php7.4-imap php7.4-interbase php7.4-intl php7.4-json php7.4-ldap \
   php7.4-mbstring php7.4-mysql php7.4-odbc php7.4-opcache php7.4-pgsql php7.4-phpdbg php7.4-pspell php7.4-readline \
   php7.4-snmp php7.4-soap php7.4-sqlite3 php7.4-sybase php7.4-tidy php7.4-xdebug php7.4-xml php7.4-xmlrpc php7.4-xsl \
-  php7.4-zip php7.4-memcached php7.4-redis
+  php7.4-zip php7.4-imagick php7.4-memcached php7.4-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/7.4/cli/php.ini


### PR DESCRIPTION
Add missing `php-imagick` extensions for supported PHP versions:

* `php5.6-imagick`
* `php7.0-imagick`
* `php7.1-imagick`
* `php7.2-imagick`
* `php7.3-imagick`
* `php7.4-imagick`