### PR TITLE
Add imagick for PHP 8.0 and PHP 8.1

### DIFF
--- a/scripts/amd64.sh
+++ b/scripts/amd64.sh
@@ -332,7 +332,7 @@ else
   php8.0-enchant php8.0-fpm php8.0-gd php8.0-gmp php8.0-imap php8.0-interbase php8.0-intl php8.0-ldap \
   php8.0-mbstring php8.0-mysql php8.0-odbc php8.0-opcache php8.0-pgsql php8.0-phpdbg php8.0-pspell php8.0-readline \
   php8.0-snmp php8.0-soap php8.0-sqlite3 php8.0-sybase php8.0-tidy php8.0-xdebug php8.0-xml php8.0-xmlrpc php8.0-xsl \
-  php8.0-zip php8.0-memcached php8.0-redis
+  php8.0-zip php8.0-imagick php8.0-memcached php8.0-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/8.0/cli/php.ini
@@ -374,7 +374,7 @@ else
   php8.1-enchant php8.1-fpm php8.1-gd php8.1-gmp php8.1-imap php8.1-interbase php8.1-intl php8.1-ldap \
   php8.1-mbstring php8.1-mysql php8.1-odbc php8.1-opcache php8.1-pgsql php8.1-phpdbg php8.1-pspell php8.1-readline \
   php8.1-snmp php8.1-soap php8.1-sqlite3 php8.1-sybase php8.1-tidy php8.1-xdebug php8.1-xml php8.1-xmlrpc php8.1-xsl \
-  php8.1-zip php8.1-memcached php8.1-redis
+  php8.1-zip php8.1-imagick php8.1-memcached php8.1-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/8.1/cli/php.ini

--- a/scripts/arm.sh
+++ b/scripts/arm.sh
@@ -332,7 +332,7 @@ else
   php8.0-enchant php8.0-fpm php8.0-gd php8.0-gmp php8.0-imap php8.0-interbase php8.0-intl php8.0-ldap \
   php8.0-mbstring php8.0-mysql php8.0-odbc php8.0-opcache php8.0-pgsql php8.0-phpdbg php8.0-pspell php8.0-readline \
   php8.0-snmp php8.0-soap php8.0-sqlite3 php8.0-sybase php8.0-tidy php8.0-xdebug php8.0-xml php8.0-xmlrpc php8.0-xsl \
-  php8.0-zip php8.0-memcached php8.0-redis
+  php8.0-zip php8.0-imagick php8.0-memcached php8.0-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/8.0/cli/php.ini
@@ -374,7 +374,7 @@ else
   php8.1-enchant php8.1-fpm php8.1-gd php8.1-gmp php8.1-imap php8.1-interbase php8.1-intl php8.1-ldap \
   php8.1-mbstring php8.1-mysql php8.1-odbc php8.1-opcache php8.1-pgsql php8.1-phpdbg php8.1-pspell php8.1-readline \
   php8.1-snmp php8.1-soap php8.1-sqlite3 php8.1-sybase php8.1-tidy php8.1-xdebug php8.1-xml php8.1-xmlrpc php8.1-xsl \
-  php8.1-zip php8.1-memcached php8.1-redis
+  php8.1-zip php8.1-imagick php8.1-memcached php8.1-redis
 
   # Configure php.ini for CLI
   sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/8.1/cli/php.ini


### PR DESCRIPTION
PHP 8.1 technically doesn't need it to be installed, but it also doesn't need redis, memcached or xdebug installed like this either so I thought I'd add it for consistencies sake.


