### PR TITLE
Install MySQL by default, not MariaDB [bugfix]

### DIFF
--- a/scripts/amd64.sh
+++ b/scripts/amd64.sh
@@ -4,8 +4,8 @@ export DEBIAN_FRONTEND=noninteractive
 ARCH=$(arch)
 
 SKIP_PHP=false
-SKIP_MYSQL=true
-SKIP_MARIADB=false
+SKIP_MYSQL=false
+SKIP_MARIADB=true
 SKIP_POSTGRESQL=false
 
 echo "### Settler Build Configuration ###"


### PR DESCRIPTION
best I can tell, commit 15193085bca2600e4b7336234debcf0a5f5e5683 accidentally mixed these values up. my guess is this was unintentional as the PR comment mentions nothing about changing the defaults.

further suggested by the fact the ARM version of the build script did not adjust these values: https://github.com/laravel/settler/blob/master/scripts/arm.sh#L14

unfortunately end user currently has no recourse to fix this on their end, as we don't provide a "feature" in `laravel/homestead` to install MySQL, as it assumes MySQL is already installed.

current solution will be to downgrade to v12.1.0 until we can get a patch base box up.