### PR TITLE
Fix PowerShell linking for AMD64 builds

### DIFF
--- a/bin/link-to-bento.ps1
+++ b/bin/link-to-bento.ps1
@@ -7,15 +7,15 @@ New-Item -Path ..\bento\packer_templates\ubuntu\http\preseed.cfg -ItemType Symbo
 New-Item -Path ..\bento\packer_templates\ubuntu\http\preseed-hyperv.cfg -ItemType SymbolicLink -Value .\http\preseed-hyperv.cfg -Force
 
 # AMD64
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace 'scripts/cleanup.sh', 'scripts/homestead.sh') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"memory": "1024"', '"memory": "2084"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"disk_size": "65536"', '"disk_size": "131072"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"boot_wait": "5s"', '"boot_wait": "3s"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"type": "hyperv-iso",', '"type": "hyperv-iso","configuration_version": "9.0",') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace 'scripts/cleanup.sh', 'scripts/homestead.sh') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"memory": "1024"', '"memory": "2084"') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"disk_size": "65536"', '"disk_size": "131072"') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"boot_wait": "5s"', '"boot_wait": "3s"') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"type": "hyperv-iso",', '"type": "hyperv-iso","configuration_version": "9.0",') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
 
 # ARM64
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace 'scripts/cleanup.sh', 'scripts/homestead-arm.sh') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"memory": "1024"', '"memory": "2084"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"disk_size": "65536"', '"disk_size": "131072"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"boot_wait": "5s"', '"boot_wait": "3s"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"type": "hyperv-iso",', '"type": "hyperv-iso","configuration_version": "9.0",') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace 'scripts/cleanup.sh', 'scripts/homestead-arm.sh') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"memory": "1024"', '"memory": "2084"') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"disk_size": "65536"', '"disk_size": "131072"') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"boot_wait": "5s"', '"boot_wait": "3s"') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"type": "hyperv-iso",', '"type": "hyperv-iso","configuration_version": "9.0",') | Set-Content -NoNewline -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json

--- a/bin/link-to-bento.ps1
+++ b/bin/link-to-bento.ps1
@@ -1,12 +1,21 @@
 ﻿# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7
 # Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-New-Item -Path ..\bento\packer_templates\ubuntu\scripts\homestead.sh -ItemType SymbolicLink -Value .\scripts\arm.sh -Force
+New-Item -Path ..\bento\packer_templates\ubuntu\scripts\homestead.sh -ItemType SymbolicLink -Value .\scripts\amd64.sh -Force
+New-Item -Path ..\bento\packer_templates\ubuntu\scripts\homestead-arm.sh -ItemType SymbolicLink -Value .\scripts\arm.sh -Force
 New-Item -Path ..\bento\packer_templates\ubuntu\http\preseed.cfg -ItemType SymbolicLink -Value .\http\preseed.cfg -Force
 New-Item -Path ..\bento\packer_templates\ubuntu\http\preseed-hyperv.cfg -ItemType SymbolicLink -Value .\http\preseed-hyperv.cfg -Force
 
-((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace 'scripts/cleanup.sh','scripts/homestead.sh') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+# AMD64
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace 'scripts/cleanup.sh', 'scripts/homestead.sh') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
 ((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"memory": "1024"', '"memory": "2084"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
 ((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"disk_size": "65536"', '"disk_size": "131072"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
 ((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"boot_wait": "5s"', '"boot_wait": "3s"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
 ((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json -Raw) -replace '"type": "hyperv-iso",', '"type": "hyperv-iso","configuration_version": "9.0",') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-amd64.json
+
+# ARM64
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace 'scripts/cleanup.sh', 'scripts/homestead-arm.sh') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"memory": "1024"', '"memory": "2084"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"disk_size": "65536"', '"disk_size": "131072"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"boot_wait": "5s"', '"boot_wait": "3s"') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json
+((Get-Content -path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json -Raw) -replace '"type": "hyperv-iso",', '"type": "hyperv-iso","configuration_version": "9.0",') | Set-Content -Path ..\bento\packer_templates\ubuntu\ubuntu-20.04-arm64.json


### PR DESCRIPTION
Trying to do my own VMWare build on Windows, but it always links the arm script.

I've copied the logic from `link-to-bento.sh`, but I've only kept the find/replaces that were already present.
I have updated the values to mirror the .sh ones though, memory 2084 to 2048, disk_size 131072 to 524288

Also used `Set-Content -NoNewLine` to stop adding new lines to end of the output.

13.x branch will need similar but it looks like it also uses a boot_wait replacement.

