### PR TITLE
use Node Version Manager (nvm)

### DIFF
--- a/scripts/amd64.sh
+++ b/scripts/amd64.sh
@@ -33,9 +33,6 @@ ca-certificates
 apt-add-repository ppa:ondrej/php -y
 apt-add-repository ppa:chris-lea/redis-server -y
 
-# NodeJS
-curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-
 # PostgreSQL
 tee /etc/apt/sources.list.d/pgdg.list <<END
 deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main
@@ -599,8 +596,9 @@ EOF
   printf "\nPATH=\"$(sudo su - vagrant -c 'composer config -g home 2>/dev/null')/vendor/bin:\$PATH\"\n" | tee -a /home/vagrant/.profile
 fi
 
-# Install Node
-apt-get install -y nodejs
+# Install Node Version Manager
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+nvm install node
 /usr/bin/npm install -g npm
 /usr/bin/npm install -g gulp-cli
 /usr/bin/npm install -g bower

--- a/scripts/arm.sh
+++ b/scripts/arm.sh
@@ -33,9 +33,6 @@ ca-certificates
 apt-add-repository ppa:ondrej/php -y
 apt-add-repository ppa:chris-lea/redis-server -y
 
-# NodeJS
-curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-
 # PostgreSQL
 tee /etc/apt/sources.list.d/pgdg.list <<END
 deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main
@@ -599,8 +596,9 @@ EOF
   printf "\nPATH=\"$(sudo su - vagrant -c 'composer config -g home 2>/dev/null')/vendor/bin:\$PATH\"\n" | tee -a /home/vagrant/.profile
 fi
 
-# Install Node
-apt-get install -y nodejs
+# Install Node Version Manager
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+nvm install node
 /usr/bin/npm install -g npm
 /usr/bin/npm install -g gulp-cli
 /usr/bin/npm install -g bower


### PR DESCRIPTION
use Node Version Manager (nvm) to install the latest version of node and NPM. NVM also allows users to install multiple versions of Node on their system and switch easily between them.  The NPM docs even strongly recommending using NVM vs the Node Installer directly, due to permissions issues.

https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

This may also ease our maintenance burden a little of having to keep up to date with the latest Node versions in our build scripts.

I ***have not*** tested these changes in an actual box build, as I don't know how to do that.