### PR TITLE
laravel/installer:^5.0

### DIFF
--- a/scripts/amd64.sh
+++ b/scripts/amd64.sh
@@ -495,7 +495,7 @@ else
   # Install Global Packages
   sudo su vagrant <<'EOF'
   /usr/local/bin/composer global require "laravel/envoy=^2.0"
-  /usr/local/bin/composer global require "laravel/installer=^4.2"
+  /usr/local/bin/composer global require "laravel/installer=^5.0"
   /usr/local/bin/composer global config --no-plugins allow-plugins.slince/composer-registry-manager true
   /usr/local/bin/composer global require "slince/composer-registry-manager=^2.0"
 EOF

--- a/scripts/arm.sh
+++ b/scripts/arm.sh
@@ -496,7 +496,7 @@ else
   # Install Global Packages
   sudo su vagrant <<'EOF'
   /usr/local/bin/composer global require "laravel/envoy=^2.0"
-  /usr/local/bin/composer global require "laravel/installer=^4.2"
+  /usr/local/bin/composer global require "laravel/installer=^5.0"
   /usr/local/bin/composer global config --no-plugins allow-plugins.slince/composer-registry-manager true
   /usr/local/bin/composer global require "slince/composer-registry-manager=^2.0"
 EOF


### PR DESCRIPTION
[v5.0](https://github.com/laravel/installer/compare/v4.5.1...v5.0.0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34) was released way back on Aug 1.
To make sure it works (I tested it on PHP v8.2) run this inside your VM:
```Shell
composer global require laravel/installer:^5.0
laravel new
```