### PR TITLE
update Ngrok installation to use repository

### DIFF
--- a/scripts/amd64.sh
+++ b/scripts/amd64.sh
@@ -811,9 +811,10 @@ systemctl enable supervisor.service
 service supervisor start
 
 # Install ngrok
-wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz
-tar xvzf ngrok-v3-stable-linux-amd64.tgz -C /usr/local/bin
-rm -rf ngrok-v3-stable-linux-amd64.tgz
+curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo gpg --dearmor -o /etc/apt/keyrings/ngrok.gpg
+echo "deb [signed-by=/etc/apt/keyrings/ngrok.gpg] https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+apt-get update
+apt-get install ngrok
 
 # Install & Configure Postfix
 echo "postfix postfix/mailname string homestead.test" | debconf-set-selections

--- a/scripts/arm.sh
+++ b/scripts/arm.sh
@@ -810,10 +810,11 @@ service mailpit restart
 systemctl enable supervisor.service
 service supervisor start
 
-# Install ngrok ARM
-wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-arm64.tgz
-tar xvzf ngrok-v3-stable-linux-arm64.tgz -C /usr/local/bin
-rm -rf ngrok-v3-stable-linux-arm64.tgz
+# Install ngrok
+curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo gpg --dearmor -o /etc/apt/keyrings/ngrok.gpg
+echo "deb [signed-by=/etc/apt/keyrings/ngrok.gpg] https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+apt-get update
+apt-get install ngrok
 
 # Install & Configure Postfix
 echo "postfix postfix/mailname string homestead.test" | debconf-set-selections


### PR DESCRIPTION
by using the repository, this will allow us to have a standard install for both our x86 and ARM versions. it will also make upgrading easier for end users by using `apt`, rather than possibly waiting for a new box build.

this change is also using the new version of key signing. the following links were spectacular resources for this process:

https://wiki.debian.org/DebianRepository/UseThirdParty
https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html
https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key?newreg=c7d51f5afac945fea79db7a504d68e76

One question I have is the DEB references "buster", which is a Debian codename. I've never fully understood what this meant, but it seems to work even though we aren't on that release. Should it be replaced with something like "stable"?