### PR TITLE
set the MySQL timezone to explicitly use UTC

### DIFF
--- a/scripts/amd64.sh
+++ b/scripts/amd64.sh
@@ -677,6 +677,8 @@ EOF
   mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'%' WITH GRANT OPTION;"
   mysql --user="root" -e "FLUSH PRIVILEGES;"
   mysql --user="root" -e "CREATE DATABASE homestead character set UTF8mb4 collate utf8mb4_bin;"
+  mysql --user="root" -e "SET GLOBAL time_zone = '+00:00';"
+  mysql --user="root" -e "SET time_zone = '+00:00';"
 
   sudo tee /home/vagrant/.my.cnf <<EOL
 [mysqld]

--- a/scripts/arm.sh
+++ b/scripts/arm.sh
@@ -677,6 +677,8 @@ EOF
   mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'%' WITH GRANT OPTION;"
   mysql --user="root" -e "FLUSH PRIVILEGES;"
   mysql --user="root" -e "CREATE DATABASE homestead character set UTF8mb4 collate utf8mb4_bin;"
+  mysql --user="root" -e "SET GLOBAL time_zone = '+00:00';"
+  mysql --user="root" -e "SET time_zone = '+00:00';"
 
   sudo tee /home/vagrant/.my.cnf <<EOL
 [mysqld]


### PR DESCRIPTION
MySQL by default uses the "SYSTEM" timezone. on most servers this is UTC, so everything is fine, but on Homestead it may sync with the host OS to a non-UTC timezone. We could try and change the guest OS timezone, but this might be difficult across the different providers and user preferences. Instead, we'll **explicitly** set the MySQL timezone to UTC.

`timestamp` column types will automatically try to convert any values they receive to UTC. most applications are already handling dates in the code, and delivering UTC values to MySQL. this can cause issues if MySQL receives a value that does not exist in it's given timezone.

for example, we recently had daylight savings time taking us from CST to CDT. The datetime between 2024-03-10 02:00:00 - 2024-03-10 02:59:59 technically does not exist, so if you try to feed this value to MySQL, it will reject the data.

---

To replicate this issue:

- confirm `date` on Homestead returns a non-UTC timezone
- confirm `SELECT @@global.time_zone, @@session.time_zone;` on MySQL returns "SYSTEM | SYSTEM"
-  try to update any timestamp column to an invalid date. for example, `UPDATE users SET created_at = '2024-03-10 02:10:10';`